### PR TITLE
Revert "chore(deps): update lscr.io/linuxserver/bazarr docker tag to v1.6.0-ls358"

### DIFF
--- a/apps/base/bazarr/deployment.yaml
+++ b/apps/base/bazarr/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         supplementalGroups: [3100]
       containers:
         - name: bazarr
-          image: lscr.io/linuxserver/bazarr:v1.6.0-ls358@sha256:b3d44d324399152be4d50775ff639a364c0fa1cfda67f71b1f38264c4d0ca09f
+          image: lscr.io/linuxserver/bazarr:v1.6.0-ls357
           ports:
             - containerPort: 6767
           securityContext:


### PR DESCRIPTION
Reverts druwan/homelab#775